### PR TITLE
releasetools: Start backuptool after flashing boot partition

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -1378,10 +1378,6 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
 
   device_specific.FullOTA_PostValidate()
 
-  if OPTIONS.backuptool:
-    script.ShowProgress(0.02, 10)
-    script.RunBackup("restore", sysmount)
-
   script.ShowProgress(0.05, 5)
   script.WriteRawImage("/boot", "boot.img")
 


### PR DESCRIPTION
* User can get "System has been destroyed" if restoring Magisk and flashing boot.img at the same time. Please restore stuff after flashing boot.

Signed-off-by: Zainudin Shamilov <renascape@beatwo.men>
Change-Id: I0e0531a418c32bd67a85bc74659cfdb4cd7a8729